### PR TITLE
Fix uninitialised variable for Peaks

### DIFF
--- a/peaks/modulations/multistage_envelope.h
+++ b/peaks/modulations/multistage_envelope.h
@@ -293,9 +293,9 @@ class MultistageEnvelope {
   }
   
  private:
-  int16_t level_[kMaxNumSegments];
-  uint16_t time_[kMaxNumSegments];
-  EnvelopeShape shape_[kMaxNumSegments];
+  int16_t level_[kMaxNumSegments] = {};
+  uint16_t time_[kMaxNumSegments] = {};
+  EnvelopeShape shape_[kMaxNumSegments] = {};
   
   int16_t segment_;
   int16_t start_value_;


### PR DESCRIPTION
shape_ is uninitialised, and causes crashes on the windows build of VCV Peaks.

analysis here: https://community.vcvrack.com/t/peaks-clone/9414/59?u=hemmer